### PR TITLE
fix visIgraphLayout problems with id column

### DIFF
--- a/R/visIgraphLayout.R
+++ b/R/visIgraphLayout.R
@@ -96,8 +96,8 @@ visIgraphLayout <- function(graph,
   
   igraphlayout <- list(type = type)
   
-  ig <- igraph::graph_from_data_frame(graph$x$edges, directed = TRUE, 
-                                      vertices = graph$x$nodes)
+    ig <- igraph::graph_from_data_frame(graph$x$edges, directed = TRUE, 
+        vertices = graph$x$nodes[,c("id", setdiff(names(graph$x$nodes), "id"))])
   
   if(!is.null(randomSeed)){
     set.seed(randomSeed)


### PR DESCRIPTION
Make sure the column comes first when passing `graph$x$nodes` to the `vertices` argument. Otherwise `igraph::graph_from_data_frame` may throw an error because of non-unique vertice ids. (Note that `visNetwork()` accepts data frames that have the `id` column not as the first column; so this may cause problems.)

```
library(visNetwork)
set.seed(1)
nnodes <- nnedges <- 25
nodes <- data.frame(label = letters[nnodes], id = 1:nnodes)
edges <- data.frame(from = sample(1:nnodes, nnedges, replace = T), 
                   to = sample(1:nnodes, nnedges, replace = T))
visNetwork(nodes, edges)
visNetwork(nodes, edges) %>% 
 visIgraphLayout()
# Error in igraph::graph_from_data_frame(graph$x$edges, directed = TRUE,  : 
#   Duplicate vertex names
visNetwork(nodes[,c("id", "label")], edges) %>% 
 visIgraphLayout()
# works
```
